### PR TITLE
solver: write nonce to correct position in header

### DIFF
--- a/equi_miner.cpp
+++ b/equi_miner.cpp
@@ -79,6 +79,7 @@ int main(int argc, char **argv) {
   }
   for (int r = 0; r < range; r++) {
     ((u32 *)headernonce)[32] = htole32(nonce+r);
+    ((u32 *)headernonce)[27] = htole32(nonce+r);
     eq.setheadernonce(headernonce, sizeof(headernonce));
     for (int t = 0; t < nthreads; t++) {
       threads[t].id = t;


### PR DESCRIPTION
The 140 byte header holds the nonce in the last 32 bytes. It hence
starts at byte-position 108, which is position 108/4=27 in `u32` terms.
It is more natural to write the `u32` (4 bytes) nonce of this particular
implementation to the first position than somewhere in the middle of the
nonce (as was the case with `u32`-position 32/byte-position 128), also
taking little-endianess into account. This way, the least significant
bit of the nonce will be written to position 108, where it should be.